### PR TITLE
enable REST response validation against OAS #16

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,9 @@ var options = {
         controllers: path.join(__dirname, './controllers')
     },
     openApiValidator: {
+        validateResponses: {
+            removeAdditional: 'all',
+        },
         validateSecurity: {
             handlers: {
                 apiKeyAuth: validateOperationKey,
@@ -40,6 +43,8 @@ var options = {
 
 var expressAppConfig = oas3Tools.expressAppConfig(path.join(__dirname, 'api/openapi.yaml'), options);
 var app = expressAppConfig.getApp();
+// format all json responses written via res.json()
+app.set('json spaces', 2);
 
 // Initialize the Swagger middleware
 http.createServer(app).listen(serverPort, function () {

--- a/server/index.js
+++ b/server/index.js
@@ -29,9 +29,7 @@ var options = {
         controllers: path.join(__dirname, './controllers')
     },
     openApiValidator: {
-        validateResponses: {
-            removeAdditional: 'all',
-        },
+        validateResponses: true,
         validateSecurity: {
             handlers: {
                 apiKeyAuth: validateOperationKey,

--- a/server/service/CoreService.js
+++ b/server/service/CoreService.js
@@ -9,7 +9,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getControlConstruct = function () {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase("core-model-1-4:control-construct");
+      var value = await fileOperation.readFromDatabaseAsync("core-model-1-4:control-construct");
       var response = {};
       response['application/json'] = {
         "core-model-1-4:control-construct": value

--- a/server/service/HttpClientService.js
+++ b/server/service/HttpClientService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getHttpClientApplicationName = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-client-interface-1-0:application-name": value
@@ -35,7 +35,7 @@ exports.getHttpClientApplicationName = function (url) {
 exports.getHttpClientReleaseNumber = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-client-interface-1-0:release-number": value

--- a/server/service/HttpServerService.js
+++ b/server/service/HttpServerService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getHttpServerApplicationName = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:application-name": value
@@ -36,7 +36,7 @@ exports.getHttpServerApplicationName = function (url) {
 exports.getHttpServerApplicationPurpose = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:application-purpose": value
@@ -62,7 +62,7 @@ exports.getHttpServerApplicationPurpose = function (url) {
 exports.getHttpServerDataUpdatePeriode = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:data-update-period": value
@@ -88,7 +88,7 @@ exports.getHttpServerDataUpdatePeriode = function (url) {
 exports.getHttpServerOwnerEmailAddress = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:owner-email-address": value
@@ -114,7 +114,7 @@ exports.getHttpServerOwnerEmailAddress = function (url) {
 exports.getHttpServerOwnerName = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:owner-name": value
@@ -140,7 +140,7 @@ exports.getHttpServerOwnerName = function (url) {
 exports.getHttpServerReleaseList = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:release-list": value
@@ -166,7 +166,7 @@ exports.getHttpServerReleaseList = function (url) {
 exports.getHttpServerReleaseNumber = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "http-server-interface-1-0:release-number": value

--- a/server/service/OperationClientService.js
+++ b/server/service/OperationClientService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getOperationClientDetailedLoggingIsOn = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-client-interface-1-0:detailed-logging-is-on": value
@@ -36,7 +36,7 @@ exports.getOperationClientDetailedLoggingIsOn = function (url) {
 exports.getOperationClientLifeCycleState = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-client-interface-1-0:life-cycle-state": value
@@ -62,7 +62,7 @@ exports.getOperationClientLifeCycleState = function (url) {
 exports.getOperationClientOperationKey = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-client-interface-1-0:operation-key": value
@@ -88,7 +88,7 @@ exports.getOperationClientOperationKey = function (url) {
 exports.getOperationClientOperationName = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-client-interface-1-0:operation-name": value
@@ -114,7 +114,7 @@ exports.getOperationClientOperationName = function (url) {
 exports.getOperationClientOperationalState = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-client-interface-1-0:operational-state": value

--- a/server/service/OperationServerService.js
+++ b/server/service/OperationServerService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getOperationServerLifeCycleState = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-server-interface-1-0:life-cycle-state": value
@@ -36,7 +36,7 @@ exports.getOperationServerLifeCycleState = function (url) {
 exports.getOperationServerOperationKey = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-server-interface-1-0:operation-key": value
@@ -63,7 +63,7 @@ exports.getOperationServerOperationKey = function (url) {
 exports.getOperationServerOperationName = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "operation-server-interface-1-0:operation-name": value

--- a/server/service/TcpClientService.js
+++ b/server/service/TcpClientService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getTcpClientRemoteIpv4Address = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "tcp-client-interface-1-0:remote-address": value
@@ -36,7 +36,7 @@ exports.getTcpClientRemoteIpv4Address = function (url) {
 exports.getTcpClientRemotePort = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "tcp-client-interface-1-0:remote-port": value

--- a/server/service/TcpServerService.js
+++ b/server/service/TcpServerService.js
@@ -10,7 +10,7 @@ var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver
 exports.getTcpServerLocalIpv4Address = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "tcp-server-interface-1-0:local-address": value
@@ -36,7 +36,7 @@ exports.getTcpServerLocalIpv4Address = function (url) {
 exports.getTcpServerLocalPort = function (url) {
   return new Promise(async function (resolve, reject) {
     try {
-      var value = await fileOperation.readFromDatabase(url);
+      var value = await fileOperation.readFromDatabaseAsync(url);
       var response = {};
       response['application/json'] = {
         "tcp-server-interface-1-0:local-port": value


### PR DESCRIPTION
Each JSON body in response is validated against OAS.
It fails with status code 500 if response is not valid.
Additional fields which are in JSON body but are not in OAS are
removed from the response.

Formatting of JSON body is also enabled when res.json() is called.

Depends on https://github.com/openBackhaul/ApplicationPattern/issues/120

Fixes #16

Signed-off-by: Martin Sunal <12826634+MartinSunal@users.noreply.github.com>