### PR TITLE
Fixed usage of FC LinkUpdateNotificationCausesOperationKeyUpdates

### DIFF
--- a/server/service/IndividualServicesService.js
+++ b/server/service/IndividualServicesService.js
@@ -25,6 +25,8 @@ const onfModelUtils = require("../utils/OnfModelUtils");
 
 const FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES_UUID = 'okm-0-0-1-op-fc-3001';
 const FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES = 'CyclicOperationCausesOperationKeyUpdates';
+const FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES_UUID = 'okm-0-0-1-op-fc-3000';
+const FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES = 'LinkUpdateNotificationCausesOperationKeyUpdates';
 
 /**
  * Initiates process of embedding a new release
@@ -127,8 +129,9 @@ exports.disregardApplication = async function (body, user, originator, xCorrelat
   const logicalTerminationPointConfigurationStatus = await logicalTerminationPointService.deleteApplicationInformationAsync(appName, appReleaseNumber);
 
   const operationClientUuid = logicalTerminationPointConfigurationStatus.operationClientConfigurationStatusList[0].uuid;
-  const forwardingConfigurationInput = new ForwardingConstructConfigurationInput(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
-  const forwardingConfigurationInputList = [forwardingConfigurationInput];
+  const cyclicOperationInput = new ForwardingConstructConfigurationInput(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
+  const linkUpdateNotificationInput = new ForwardingConstructConfigurationInput(FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
+  const forwardingConfigurationInputList = [cyclicOperationInput, linkUpdateNotificationInput];
   const forwardingConstructConfigurationStatus = await forwardingConfigurationService.unConfigureForwardingConstructAsync(operationServerName, forwardingConfigurationInputList);
 
   let applicationLayerTopologyForwardingInputList = await prepareALTForwardingAutomation.getALTUnConfigureForwardingAutomationInputAsync(
@@ -210,8 +213,9 @@ exports.regardApplication = async function (body, user, originator, xCorrelator,
   const logicalTerminationPointConfigurationStatus = await logicalTerminationPointService.createOrUpdateApplicationInformationAsync(logicalTerminatinPointConfigurationInput);
 
   const operationClientUuid = logicalTerminationPointConfigurationStatus.operationClientConfigurationStatusList[0].uuid;
-  const forwardingConfigurationInput = new ForwardingConstructConfigurationInput(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
-  const forwardingConfigurationInputList = [forwardingConfigurationInput];
+  const cyclicOperationInput = new ForwardingConstructConfigurationInput(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
+  const linkUpdateNotificationInput = new ForwardingConstructConfigurationInput(FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES, operationClientUuid);
+  const forwardingConfigurationInputList = [cyclicOperationInput, linkUpdateNotificationInput];
   const forwardingConstructConfigurationStatus = await forwardingConfigurationService.configureForwardingConstructAsync(operationServerName, forwardingConfigurationInputList);
 
   let applicationLayerTopologyForwardingInputList = await prepareALTForwardingAutomation.getALTForwardingAutomationInputAsync(
@@ -245,7 +249,7 @@ exports.regardUpdatedLink = async function (body, user, originator, xCorrelator,
   // get data from request body
   const linkUuid = body['link-uuid'];
 
-  const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES_UUID);
+  const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES_UUID);
   const httpClient = new HttpClient(user, xCorrelator, traceIndicator, customerJourney);
   await updateOperationKeyForLink(linkUuid, updateKeyOperationLtpUuidList, httpClient);
 }

--- a/server/service/IndividualServicesService.js
+++ b/server/service/IndividualServicesService.js
@@ -23,9 +23,7 @@ const ltpClientConstants = require('../utils/ltpClientConstants');
 const ltpServerConstants = require('../utils/ltpServerConstants');
 const onfModelUtils = require("../utils/OnfModelUtils");
 
-const FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES_UUID = 'okm-0-0-1-op-fc-3001';
 const FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES = 'CyclicOperationCausesOperationKeyUpdates';
-const FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES_UUID = 'okm-0-0-1-op-fc-3000';
 const FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES = 'LinkUpdateNotificationCausesOperationKeyUpdates';
 
 /**
@@ -161,7 +159,7 @@ exports.disregardApplication = async function (body, user, originator, xCorrelat
  * returns List
  **/
 exports.listApplications = async function (user, originator, xCorrelator, traceIndicator, customerJourney) {
-  const clientOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES_UUID);
+  const clientOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForForwardingName(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES);
   const resultList = [];
   for (const clientOperationLtpUuid of clientOperationLtpUuidList) {
     const httpLtpUuidList = await LogicalTerminationPoint.getServerLtpListAsync(clientOperationLtpUuid);
@@ -249,7 +247,7 @@ exports.regardUpdatedLink = async function (body, user, originator, xCorrelator,
   // get data from request body
   const linkUuid = body['link-uuid'];
 
-  const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES_UUID);
+  const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForForwardingName(FC_LINK_UPDATE_NOTIFICATION_CAUSES_OPERATION_KEY_UPDATES);
   const httpClient = new HttpClient(user, xCorrelator, traceIndicator, customerJourney);
   await updateOperationKeyForLink(linkUuid, updateKeyOperationLtpUuidList, httpClient);
 }
@@ -293,7 +291,7 @@ exports.scheduleKeyRotation = function scheduleKeyRotation(intervalInMinutes) {
 
 async function reccurentUpdateKeys() {
   try {
-    const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES_UUID);
+    const updateKeyOperationLtpUuidList = await onfModelUtils.getFcPortOutputDirectionLogicalTerminationPointListForForwardingName(FC_CYCLIC_OPERATION_CAUSES_OPERATION_KEY_UPDATES);
     const httpClient = new HttpClient();
     const linkUuidList = await fetchLinkUuidListFromAlt(httpClient);
     for (const linkUuid of linkUuidList) {

--- a/server/utils/OnfModelUtils.js
+++ b/server/utils/OnfModelUtils.js
@@ -5,9 +5,13 @@ const onfAttributes = require('onf-core-model-ap/applicationPattern/onfModel/con
 const ForwardingDomain = require("onf-core-model-ap/applicationPattern/onfModel/models/ForwardingDomain");
 const FcPort = require("onf-core-model-ap/applicationPattern/onfModel/models/FcPort");
 
-exports.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid = async function getFcPortOutputDirectionLogicalTerminationPointListForTheUuid(forwardingConstructUuid) {
+exports.getFcPortOutputDirectionLogicalTerminationPointListForForwardingName = async function getFcPortOutputDirectionLogicalTerminationPointListForForwardingName(forwardingName) {
   let fcPortOutputDirectionLogicalTerminationPointList = [];
-  const forwardingConstruct = await findForwardingConstructByUuid(forwardingConstructUuid);
+  const forwardingConstruct = await ForwardingDomain.getForwardingConstructForTheForwardingNameAsync(forwardingName);
+  if (forwardingConstruct === undefined) {
+    return fcPortOutputDirectionLogicalTerminationPointList;
+  }
+
   const fcPortList = forwardingConstruct[onfAttributes.FORWARDING_CONSTRUCT.FC_PORT];
   for (const fcPort of fcPortList) {
     const portDirection = fcPort[onfAttributes.FC_PORT.PORT_DIRECTION];
@@ -16,15 +20,4 @@ exports.getFcPortOutputDirectionLogicalTerminationPointListForTheUuid = async fu
     }
   }
   return fcPortOutputDirectionLogicalTerminationPointList;
-}
-
-async function findForwardingConstructByUuid(forwardingConstructUuid) {
-  let forwardingConstructList = await ForwardingDomain.getForwardingConstructListAsync();
-  for (let i = 0; i < forwardingConstructList.length; i++) {
-    let forwardingConstruct = forwardingConstructList[i];
-    if (forwardingConstruct.uuid === forwardingConstructUuid) {
-      return forwardingConstruct;
-    }
-  }
-  return undefined;
 }


### PR DESCRIPTION
- /v1/regard-application adds FC-port to LinkUpdateNotificationCausesOperationKeyUpdates
- /v1/disregard-application removes FC-port from LinkUpdateNotificationCausesOperationKeyUpdates
- /v1/regard-updated-link checks if endpoints of link-uuid are located in LTPs from FC-ports of LinkUpdateNotificationCausesOperationKeyUpdates

Fixes #42

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>