### PR TITLE
Implemented behavior based on "operationName" value

### DIFF
--- a/server/database/load.json
+++ b/server/database/load.json
@@ -11,7 +11,7 @@
               "string-name": "operationMode"
             },
             "string-profile-configuration": {
-              "string-value": "string-profile-1-0:STRING_VALUE_TYPE_SANITATION"
+              "string-value": "string-profile-1-0:STRING_VALUE_TYPE_PROTECTION"
             }
           }
         }

--- a/server/index.js
+++ b/server/index.js
@@ -32,4 +32,4 @@ http.createServer(app).listen(serverPort, function () {
 //setting the path to the database 
 global.databasePath = './database/load.json'
 
-individualServicesService.scheduleKeyRotation(5); // update operation key every 5 minutes
+individualServicesService.scheduleKeyRotation();

--- a/server/service/StringProfileService.js
+++ b/server/service/StringProfileService.js
@@ -1,6 +1,12 @@
+// @ts-check
 'use strict';
 
 var fileOperation = require('onf-core-model-ap/applicationPattern/databaseDriver/JSONDriver');
+var onfPaths = require('onf-core-model-ap/applicationPattern/onfModel/constants/OnfPaths');
+var profileConstants = require('../utils/profileConstants');
+var individualServicesService = require('./IndividualServicesService');
+
+const operationModeStringValuePath = `${onfPaths.PROFILE}=okm-0-0-1-string-p-0000/string-profile-1-0:string-profile-pac/string-profile-configuration/string-value`;
 
 /**
  * Returns the name of the String
@@ -61,7 +67,14 @@ exports.getStringProfileStringValue = function (url) {
 exports.putStringProfileStringValue = function (body, url) {
   return new Promise(async function (resolve, reject) {
     try {
+      const currentOperationModeValue = await exports.getOperationModeProfileStringValue();
+      const newOperationModeValue = body['string-profile-1-0:string-value'];
       await fileOperation.writeToDatabaseAsync(url, body, false);
+      console.log(`Profile "operationMode" changed from "${currentOperationModeValue}" to "${newOperationModeValue}"`);
+      if (currentOperationModeValue === profileConstants.OPERATION_MODE_REACTIVE
+        && newOperationModeValue !== profileConstants.OPERATION_MODE_REACTIVE) {
+        individualServicesService.scheduleKeyRotation();
+      }
       resolve();
     } catch (err) {
       reject(err);
@@ -69,3 +82,17 @@ exports.putStringProfileStringValue = function (body, url) {
   });
 }
 
+/**
+ * Returns the configured value of the "operationMode" profile
+ * @returns {Promise<string>}
+ */
+exports.getOperationModeProfileStringValue = async function() {
+  return new Promise(async function (resolve, reject) {
+    try {
+      const value = await fileOperation.readFromDatabaseAsync(operationModeStringValuePath);
+      resolve(value);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/server/utils/profileConstants.js
+++ b/server/utils/profileConstants.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze({
+  OPERATION_MODE_REACTIVE: 'string-profile-1-0:STRING_VALUE_TYPE_REACTIVE',
+  OPERATION_MODE_PROTECTION: 'string-profile-1-0:STRING_VALUE_TYPE_PROTECTION',
+  OPERATION_MODE_OFF: 'string-profile-1-0:STRING_VALUE_TYPE_OFF',
+});


### PR DESCRIPTION
This is behavior for each value:
- string-profile-1-0:STRING_VALUE_TYPE_PROTECTION
  - update key is done in every 5min
  - /v1/regard-updated-link does not update keys and returns status code 500
- string-profile-1-0:STRING_VALUE_TYPE_REACTIVE
  - update key does not execute periodically
  - /v1/regard-updated-link updates keys
- string-profile-1-0:STRING_VALUE_TYPE_OFF
  - update key does not execute periodically
  - /v1/regard-updated-link does not update keys and returns status code 500

Fixes #46

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>