### PR TITLE
Resolve Convert subscriptionName  to tostring() in the PromptForBequeathingDataCausesRObeingRequestedToStopNotificationsToOldRelease method

### DIFF
--- a/server/service/individualServices/SoftwareUpgrade.js
+++ b/server/service/individualServices/SoftwareUpgrade.js
@@ -417,7 +417,7 @@ async function PromptForBequeathingDataCausesRObeingRequestedToStopNotifications
           let requestBody = {};
           requestBody.subscriberApplication = applicationName;
           requestBody.subscriberReleaseNumber = releaseNumber;
-          requestBody.subscription = subscriptionName;
+          requestBody.subscription = subscriptionName.toString();
           requestBody = onfAttributeFormatter.modifyJsonObjectKeysToKebabCase(requestBody);
           result = await forwardRequest(
             forwardingKindNameOfTheBequeathOperation,


### PR DESCRIPTION
Fixes #186